### PR TITLE
Updating BRS cleaner scripts

### DIFF
--- a/BDIGAD_data_cleaner.py
+++ b/BDIGAD_data_cleaner.py
@@ -1,0 +1,100 @@
+import pandas as pd
+from datetime import datetime
+
+IDs_correction_rules = [
+
+    {
+        "wrong_id": 'BRS0190',
+        "correct_id":'BRS0196',
+        "registered_date": "5/30/2025  12:26:14",
+        "reason": "Typo in registered ID",
+    },
+
+    {
+        "wrong_id": 'BRS0281',
+        "correct_id":'BRS0280',
+        "registered_date": "7/24/2025  10:25:30",
+        "reason": "Typo in registered ID",
+    }
+
+]
+
+# Define a function to TBA
+def normalize_ids(value: str) -> str:
+    return (
+        str(value)
+        .strip()
+        .upper()
+        .replace(" ", "")
+    )
+
+# Define a function to TBA
+def apply_correct_id(df, id_col='QID1', date_col='RecordedDate'):
+    df = df.copy()
+    
+    df["raw_id"] = df[id_col].astype(str)
+
+    df["fixed_id"] = df[id_col].apply(normalize_ids)
+
+    df["id_resolution_reason"] = "original"
+
+    df[date_col] = pd.to_datetime(df[date_col], errors="coerce")
+
+    print(df[date_col])
+
+    for rule in IDs_correction_rules:
+        rule_date = pd.to_datetime(rule["registered_date"], errors="coerce")
+
+        print(f"Wrong ID: {rule["wrong_id"]}")
+        print(f"Correct ID: {rule["correct_id"]}")
+        print(f"Date: {rule_date}")
+
+        mask = (
+            (df[id_col] == normalize_ids(rule["wrong_id"])) &
+            (df[date_col] == rule_date)
+        )
+
+        print(df[mask])
+
+        df.loc[mask, "fixed_id"] = normalize_ids(rule["correct_id"])
+        df.loc[mask, "id_resolution_reason"] = rule["reason"]
+
+    #df[date_col] = df[date_col].dt.strftime(date_format)
+
+    return df
+
+# Load the CSV file
+input_file = "/Users/cjimenez/Documents/BRS/DataManagement/Data_Transfer/Completeness-files/bdigad_downloads/desc-summary_date-20260428_bdigad.csv"
+df = pd.read_csv(input_file, encoding="utf-8")
+print(f"Initial number of rows: {len(df)}")
+
+fixed_df = apply_correct_id(df)
+
+export_df = fixed_df.copy()
+export_df['QID1'] = export_df['fixed_id']
+
+export_df = export_df.drop(columns=['raw_id','fixed_id', 'id_resolution_reason'])
+
+# Rename BDI columns Q46–Q66 to QBDI1–QBDI21
+bdi_cols = [f"Q{q}" for q in range(46, 67)]
+bdi_renamed = {old: f"QBDI{i+1}" for i, old in enumerate(bdi_cols)}
+
+# Rename BAI (GAD-7) columns Q68_1–Q68_7 to QGAD1–QGAD7
+gad_cols = [f"Q68_{i}" for i in range(1, 8)]
+gad_renamed = {old: f"QGAD{i}" for i, old in enumerate(gad_cols)}
+
+# Apply renaming
+export_df.rename(columns={**bdi_renamed, **gad_renamed}, inplace=True)
+
+# List of IDs to be removed
+excluded_IDs = ['BRS0197', 'BRS0307', 'BRS0376']
+
+# Remove rows that match with excluded IDs
+export_df = export_df[~export_df.iloc[:, 10].isin(excluded_IDs)].reset_index(drop=True)
+print(f"After excluded participant IDs: {len(export_df)}")
+
+# Save to TSV with UTF-8 encoding
+output_file = input_file.replace(".csv", ".tsv")
+export_df.to_csv(output_file, sep="\t", index=False, encoding="utf-8")
+
+print(f"Saved cleaned TSV file to {output_file}")

--- a/CANTAB_data_cleaner.py
+++ b/CANTAB_data_cleaner.py
@@ -1,28 +1,116 @@
 import pandas as pd
 
+IDs_correction_rules = [
+
+    {
+        "wrong_id": "1287",
+        "correct_id": "0287",
+        "registered_date": "2025.07.10 14:13:20",
+        "reason": "Typo in registered ID",
+    },
+
+    {
+        "wrong_id": "1469",
+        "correct_id": "0469",
+        "registered_date": "2025.10.29 11:43:25",
+        "reason": "Typo in registered ID",
+    },
+
+    {
+        "wrong_id": "5533",
+        "correct_id": "0553",
+        "registered_date": "2025.12.12 13:36:17",
+        "reason": "Typo in registered ID",
+    }
+]
+
+# Define a function to TBA
+def normalize_ids(value: str) -> str:
+    return (
+        str(value)
+        .strip()
+        .upper()
+        .replace(" ", "")
+    )
+
+# Define a function to TBA
+def apply_correct_id(df, id_col='new subject ID', date_col='Visit Start (Local)', date_format='%Y.%m.%d %H:%M:%S'):
+    df = df.copy()
+    
+    df["raw_id"] = df[id_col].astype(str)
+
+    df["fixed_id"] = df[id_col].apply(normalize_ids)
+
+    df["id_resolution_reason"] = "original"
+
+    df[date_col] = pd.to_datetime(df[date_col], errors="coerce")
+
+    print(df[date_col])
+
+    for rule in IDs_correction_rules:
+        rule_date = pd.to_datetime(rule["registered_date"], errors="coerce")
+
+        print(f"Wrong ID: {rule["wrong_id"]}")
+        print(f"Correct ID: {rule["correct_id"]}")
+        print(f"Date: {rule_date}")
+
+        mask = (
+            (df[id_col] == normalize_ids(rule["wrong_id"])) &
+            (df[date_col] == rule_date)
+        )
+
+        print(df[mask])
+
+        df.loc[mask, "fixed_id"] = normalize_ids(rule["correct_id"])
+        df.loc[mask, "id_resolution_reason"] = rule["reason"]
+
+    df[date_col] = df[date_col].dt.strftime(date_format)
+
+    return df
+
 # Read the CSV file without specifying dtype initially
 file_path = '/Users/brs/Documents/cantab_downloads/desc-summary_date-20250612_cantab.csv'
 
 # Read the CSV to get the column names first
 df = pd.read_csv(file_path)
 
-# Specify the dtype for the Participant ID column (assuming it's column 5, index 4)
-dtype_spec = {df.columns[4]: str}  # Adjust index if the Participant ID column is different
+# Specify the dtype for the Participant ID column (assuming it's column 6, index 5)
+dtype_spec = {df.columns[5]: str}  # Adjust index if the Participant ID column is different
 
 # Now read the CSV again with the specified dtype for the Participant ID column
 df = pd.read_csv(file_path, dtype=dtype_spec)
 
+fixed_df = apply_correct_id(df)
+
+fixed_df['new subject ID'] = fixed_df['fixed_id']
+
+fixed_df = fixed_df.drop(columns=['raw_id','fixed_id', 'id_resolution_reason'])
+
 # Columns 19 to 23 (0-indexed, so columns 18 to 22)
-columns_to_check = df.columns[18:23]
+columns_to_check = fixed_df.columns[18:23]
 
+df_cleaned = fixed_df.copy()
 # Remove rows where all columns 19 to 23 have the value 'NOT_RUN'
-df_cleaned = df[~df[columns_to_check].eq('NOT_RUN').all(axis=1)]
+df_cleaned = fixed_df[~fixed_df[columns_to_check].eq('NOT_RUN').all(axis=1)]
 
-# Remove all data in Columns 6 and 7 (index 5 and 6) except for the header
-df_cleaned[df_cleaned.columns[5]] = None  # Column 6 (index 5)
+# Remove all data in Columns 7 and 8 (index 6 and 7) except for the header
 df_cleaned[df_cleaned.columns[6]] = None  # Column 7 (index 6)
+df_cleaned[df_cleaned.columns[7]] = None  # Column 8 (index 7)
+
+print(f"Before removing excluded participant IDs: {len(df_cleaned)}")
+
+# List of IDs to be removed
+excluded_IDs = ['0197', '0307', '0376']
+
+# Remove rows that match with excluded IDs
+df_cleaned = df_cleaned[~df_cleaned['new subject ID'].isin(excluded_IDs)].reset_index(drop=True)
+
+print(f"After removing excluded participant IDs: {len(df_cleaned)}")
+
+df_nodups = df_cleaned.drop_duplicates(subset='new subject ID', keep='last', inplace=False)
 
 # Save the cleaned data back to the same CSV file (overwrite the original)
-df_cleaned.to_csv(file_path, index=False)
+tsv_path = file_path.replace('.csv', '.tsv')
+df_nodups.to_csv(tsv_path, sep='\t', index=False, encoding="utf-8")
 
 print(f"Original file has been replaced with the cleaned data: {file_path}")

--- a/MoCA_data_cleaner.py
+++ b/MoCA_data_cleaner.py
@@ -1,6 +1,25 @@
 import pandas as pd
 from datetime import datetime
 
+# Function to standardize date field from MoCA csv file
+def parse_mixed_date(date_str):
+    if pd.isna(date_str):
+        return pd.NaT
+
+    date_str = str(date_str).strip()
+
+    try:
+        if "-" in date_str:
+            # dd-mm-yyyy
+            return pd.to_datetime(date_str, format="%d-%m-%Y")
+        elif "/" in date_str:
+            # mm/dd/yyyy
+            return pd.to_datetime(date_str, format="%m/%d/%Y")
+        else:
+            return pd.NaT
+    except ValueError:
+        return pd.NaT
+
 # Define the cutoff date for your study
 cutoff_date = datetime(2024, 10, 23)
 
@@ -8,13 +27,36 @@ cutoff_date = datetime(2024, 10, 23)
 file_path = "/Users/brs/Documents/moca_downloads/desc-summary_date-250502_moca.csv"  # Replace with your actual file path
 df = pd.read_csv(file_path)
 
+# Apply functon to your date column
+df['Test Upload Date'] = df['Test Upload Date'].apply(parse_mixed_date)
+
 # Ensure the date column is in datetime format
 df['Test Date'] = pd.to_datetime(df.iloc[:, 3], format='%d-%m-%Y')
 
+# Delete unnecessary spaces at the beginning of IDs
+df['Institute File number'] = df['Institute File number'].str.strip()
+
+# Remove 'sub-' part of the id, if exists
+df['Institute File number'] = df['Institute File number'].str.replace('sub-', '')
+
 # Filter out rows with a test date before the cutoff date
 filtered_df = df[df['Test Date'] >= cutoff_date]
+print(f"Before removing excluded participant IDs: {len(filtered_df)}")
+
+# List of IDs to be removed
+excluded_IDs = ['BRS0197', 'BRS0307', 'BRS0376']
+
+# Remove rows that match with excluded IDs
+filtered_df = filtered_df[~filtered_df['Institute File number'].isin(excluded_IDs)].reset_index(drop=True)
+
+print(f"After removing excluded participant IDs: {len(filtered_df)}")
 
 # Overwrite the original file with the filtered data
 filtered_df.to_csv(file_path, index=False)
+# Save to TSV with UTF-8 encoding
+output_file = file_path.replace(".csv", ".tsv")
+filtered_df.to_csv(output_file, sep="\t", index=False, encoding="utf-8")
+
+print(f"The filtered data has been saved as a TSV: {output_file}")
 
 print(f"The original file has been updated with the filtered data: {file_path}")

--- a/PSQI_data_cleaner.py
+++ b/PSQI_data_cleaner.py
@@ -2,9 +2,85 @@ import pandas as pd
 import re
 from datetime import datetime
 
-# Load the TSV file into a pandas DataFrame with the correct encoding
-file_path = '/Users/brs/Documents/psqi_downloads/desc-summary_date-250303_psqi.tsv'
-df = pd.read_csv(file_path, sep='\t', encoding='ISO-8859-1')  # Try 'ISO-8859-1' encoding
+IDs_correction_rules = [
+
+    {
+        "wrong_id": 'BRS0012',
+        "correct_id":'BRS0011',
+        "registered_date": "02/12/2024",
+        "reason": "Typo in registered ID",
+    },
+
+    {
+        "wrong_id": 'BRS0072',
+        "correct_id":'BRS0074',
+        "registered_date": "27/02/2025",
+        "reason": "Typo in registered ID",
+    },
+
+    {
+        "wrong_id": 'BRS0262',
+        "correct_id":'BRS0162',
+        "registered_date": "30/04/2025",
+        "reason": "Typo in registered ID",
+    },
+
+    {
+        "wrong_id": 'BRS0533',
+        "correct_id":'BRS0553',
+        "registered_date": "12/12/2025",
+        "reason": "Typo in registered ID",
+    },
+
+    {
+        "wrong_id": 'BRS0000',
+        "correct_id":'BRS0575',
+        "registered_date": "02/04/2026",
+        "reason": "Typo in registered ID",
+    }
+]
+
+
+def normalize_ids(value: str) -> str:
+    return (
+        str(value)
+        .strip()
+        .upper()
+        .replace(" ", "")
+    )
+
+
+def apply_correct_id(df, id_col='QID1', date_col='QID2', date_format='%d/%m/%Y'):
+    df = df.copy()
+    
+    df["raw_id"] = df[id_col].astype(str)
+
+    df["fixed_id"] = df[id_col].apply(normalize_ids)
+
+    df["id_resolution_reason"] = "original"
+
+    df[date_col] = pd.to_datetime(df[date_col], dayfirst=True, errors="coerce").dt.normalize()
+
+    for rule in IDs_correction_rules:
+        rule_date = pd.to_datetime(rule["registered_date"], dayfirst=True). normalize()
+
+        print(f"Wrong ID: {rule["wrong_id"]}")
+        print(f"Correct ID: {rule["correct_id"]}")
+        print(f"Date: {rule["registered_date"]}")
+
+        mask = (
+            (df[id_col] == normalize_ids(rule["wrong_id"])) &
+            (df[date_col] == rule_date)
+        )
+
+        print(df[mask])
+
+        df.loc[mask, "fixed_id"] = normalize_ids(rule["correct_id"])
+        df.loc[mask, "id_resolution_reason"] = rule["reason"]
+
+    df[date_col] = df[date_col].dt.strftime(date_format)
+
+    return df
 
 # Define a function to check if a participant ID follows the correct format
 def is_valid_participant_id(participant_id):
@@ -13,28 +89,42 @@ def is_valid_participant_id(participant_id):
         return bool(re.match(r'^BRS\d{4}$', participant_id))
     return False
 
+# Load the TSV file into a pandas DataFrame with the correct encoding
+file_path = '/Users/brs/Documents/psqi_downloads/desc-summary_date-250303_psqi.tsv'
+df = pd.read_csv(file_path, sep='\t', encoding='ISO-8859-1')  # Try 'ISO-8859-1' encoding
+print(f"Initial number of rows: {len(df)}")
+
+fixed_df = apply_correct_id(df)
+
+print(fixed_df.columns.tolist())
+
+export_df = fixed_df.copy()
+export_df['QID1'] = export_df['fixed_id']
+
+export_df = export_df.drop(columns=['raw_id','fixed_id', 'id_resolution_reason'])
+
+# List of IDs to be excluded
+excluded_IDs = ['BRS0197', 'BRS0307', 'BRS0376']
+
 # Remove rows with invalid participant IDs
-df = df[df.iloc[:, 10].apply(is_valid_participant_id)]  # Column 11 is index 10 in Python
+export_df = export_df[export_df.iloc[:, 10].apply(is_valid_participant_id)]  # Column 11 is index 10 in Python
+print(f"After removing invalid participant IDs: {len(export_df)}")
+
+# Remove rows that match with excluded IDs
+export_df = export_df[~export_df.iloc[:, 10].isin(excluded_IDs)].reset_index(drop=True)
+print(f"After excluded participant IDs: {len(export_df)}")
 
 # Remove rows with participant ID "BRS9999"
 df = df[df.iloc[:, 10] != 'BRS9999']
+print(f"After removing BRS9999: {len(export_df)}")
 
-# Remove rows where participant ID is "BRS1234" and the date is before March 1st, 2025
-def filter_brs1234_date(row):
-    if row.iloc[10] == 'BRS1234':  # Access the 11th column by position (index 10)
-        # Convert the date string to a datetime object
-        try:
-            date = datetime.strptime(row.iloc[11], '%d/%m/%Y')  # Access the 12th column by position (index 11)
-            # Compare the date with March 1st, 2025
-            return date >= datetime(2025, 3, 1)
-        except ValueError:
-            # If the date conversion fails, return False (remove the row)
-            return False
-    return True
+export_df = export_df[export_df.iloc[:, 10] != 'BRS1234']  # Apply the filtering function row-wise
+print(f"After filtering BRS1234: {len(export_df)}")
 
-df = df[df.apply(filter_brs1234_date, axis=1)]  # Apply the filtering function row-wise
+export_df = export_df.drop_duplicates(subset='QID1', keep='last', inplace=False)
 
-# Overwrite the original file with the cleaned data
-df.to_csv(file_path, sep='\t', index=False)
+# Save cleaned data to a new TSV file with UTF-8 encoding
+output_file = file_path.replace(".csv", ".tsv")
+export_df.to_csv(output_file, sep="\t", index=False, encoding="utf-8")
 
 print("Data cleaning complete. Original file has been overwritten.")

--- a/PSQI_data_cleaner.py
+++ b/PSQI_data_cleaner.py
@@ -115,7 +115,7 @@ export_df = export_df[~export_df.iloc[:, 10].isin(excluded_IDs)].reset_index(dro
 print(f"After excluded participant IDs: {len(export_df)}")
 
 # Remove rows with participant ID "BRS9999"
-df = df[df.iloc[:, 10] != 'BRS9999']
+export_df = export_df[export_df.iloc[:, 10] != 'BRS9999']
 print(f"After removing BRS9999: {len(export_df)}")
 
 export_df = export_df[export_df.iloc[:, 10] != 'BRS1234']  # Apply the filtering function row-wise

--- a/data_completeness_data_cleaner.py
+++ b/data_completeness_data_cleaner.py
@@ -1,0 +1,30 @@
+import pandas as pd
+# Read the CSV file without specifying dtype initially
+file_path = '/Users/cjimenez/Documents/BRS/DataManagement/Data_Transfer/Completeness-files/data_completeness_downloads/data_completeness_date-20260525.csv'
+
+# List of IDs to be removed
+excluded_IDs = ['sub-BRS0197', 'sub-BRS0307', 'sub-BRS0376']
+
+# Read the CSV 
+df = pd.read_csv(file_path)
+print(f"Before removing excluded participant IDs: {len(df)}")
+
+# Define column indexes for anonymizing excluded rows
+id_idx = 0
+datetime_idx = 1
+columns_range = range(2, 14)
+
+# Create mask based on ID column
+mask = df.iloc[:, id_idx].isin(excluded_IDs)
+
+# Apply -1 to selected non-datetime columns
+df.iloc[mask, columns_range] = -1
+
+# Apply NaT to datetime column
+df.iloc[mask, datetime_idx] = pd.NaT
+
+# Save cleaned data to a new TSV file with UTF-8 encoding
+output_file = file_path.replace(".csv", ".tsv")
+df.to_csv(output_file, sep="\t", index=False, encoding="utf-8")
+
+print(f"Data cleaning complete. Saved to {output_file}")


### PR DESCRIPTION
Updating the BRS cleaner scripts for BDIGAD, CANTAB, MoCA, PSQI, and completeness files. More details were included in the commit messages for each script, but generally the changes include:

- Filtering excluded participants' IDs
- Standardizing columns
- Functions to handle mistyped participants' IDs
- Adding scripts that were not in the repository